### PR TITLE
Fix distances reader

### DIFF
--- a/ripser.cpp
+++ b/ripser.cpp
@@ -916,9 +916,8 @@ sparse_distance_matrix read_sparse_distance_matrix(std::istream& input_stream) {
 compressed_lower_distance_matrix read_lower_distance_matrix(std::istream& input_stream) {
 	std::vector<value_t> distances;
 	value_t value;
-	while (input_stream >> value) {
+	while ((value = next_value_stream(input_stream)) && !std::isnan(value)) {
 		distances.push_back(value);
-		input_stream.ignore();
 	}
 
 	return compressed_lower_distance_matrix(std::move(distances));
@@ -927,9 +926,8 @@ compressed_lower_distance_matrix read_lower_distance_matrix(std::istream& input_
 compressed_lower_distance_matrix read_upper_distance_matrix(std::istream& input_stream) {
 	std::vector<value_t> distances;
 	value_t value;
-	while (input_stream >> value) {
+	while ((value = next_value_stream(input_stream)) && !std::isnan(value)) {
 		distances.push_back(value);
-		input_stream.ignore();
 	}
 
 	return compressed_lower_distance_matrix(compressed_upper_distance_matrix(std::move(distances)));
@@ -942,9 +940,8 @@ compressed_lower_distance_matrix read_distance_matrix(std::istream& input_stream
 	value_t value;
 	for (int i = 0; std::getline(input_stream, line); ++i) {
 		std::istringstream s(line);
-		for (int j = 0; j < i && s >> value; ++j) {
+		for (int j = 0; j < i && (value = next_value_stream(s)) && !std::isnan(value); ++j) {
 			distances.push_back(value);
-			s.ignore();
 		}
 	}
 

--- a/ripser.cpp
+++ b/ripser.cpp
@@ -835,10 +835,11 @@ template <typename T> T read(std::istream& input_stream) {
 	return result;
 }
 
-template <typename T> value_t next_value_stream(T& s) {
+template <typename T> bool next_value_stream(T& s, value_t& next_value) {
 	value_t value;
 	std::string tmp;
 	bool valid = false;
+
 	if (s >> value || !s.eof()) {
 		/* Any input stream fails to convert correctly when Inf or NaN is
 		 * present, this checks if it encounters this kind of values
@@ -847,17 +848,18 @@ template <typename T> value_t next_value_stream(T& s) {
 		if (s.fail()) {
 			s.clear();
 			s >> tmp;
-			value = std::stof(tmp.c_str());
+			next_value = std::stof(tmp.c_str());
+		} else {
+			next_value = value;
 		}
 
 		/* This check prevent encountering any zero values in distances matrices */
-		if (value != 0) valid = true;
+		if (next_value != 0) valid = true;
 	}
 
 	s.ignore();
-	return valid ? value : NAN;
+	return valid;
 }
-
 
 compressed_lower_distance_matrix read_point_cloud(std::istream& input_stream) {
 	std::vector<std::vector<value_t>> points;
@@ -916,9 +918,7 @@ sparse_distance_matrix read_sparse_distance_matrix(std::istream& input_stream) {
 compressed_lower_distance_matrix read_lower_distance_matrix(std::istream& input_stream) {
 	std::vector<value_t> distances;
 	value_t value;
-	while ((value = next_value_stream(input_stream)) && !std::isnan(value)) {
-		distances.push_back(value);
-	}
+	while (next_value_stream(input_stream, value)) { distances.push_back(value); }
 
 	return compressed_lower_distance_matrix(std::move(distances));
 }
@@ -926,9 +926,7 @@ compressed_lower_distance_matrix read_lower_distance_matrix(std::istream& input_
 compressed_lower_distance_matrix read_upper_distance_matrix(std::istream& input_stream) {
 	std::vector<value_t> distances;
 	value_t value;
-	while ((value = next_value_stream(input_stream)) && !std::isnan(value)) {
-		distances.push_back(value);
-	}
+	while (next_value_stream(input_stream, value)) { distances.push_back(value); }
 
 	return compressed_lower_distance_matrix(compressed_upper_distance_matrix(std::move(distances)));
 }
@@ -940,9 +938,7 @@ compressed_lower_distance_matrix read_distance_matrix(std::istream& input_stream
 	value_t value;
 	for (int i = 0; std::getline(input_stream, line); ++i) {
 		std::istringstream s(line);
-		for (int j = 0; j < i && (value = next_value_stream(s)) && !std::isnan(value); ++j) {
-			distances.push_back(value);
-		}
+		for (int j = 0; j < i && next_value_stream(s, value); ++j) { distances.push_back(value); }
 	}
 
 	return compressed_lower_distance_matrix(std::move(distances));

--- a/ripser.cpp
+++ b/ripser.cpp
@@ -835,6 +835,30 @@ template <typename T> T read(std::istream& input_stream) {
 	return result;
 }
 
+template <typename T> value_t next_value_stream(T& s) {
+	value_t value;
+	std::string tmp;
+	bool valid = false;
+	if (s >> value || !s.eof()) {
+		/* Any input stream fails to convert correctly when Inf or NaN is
+		 * present, this checks if it encounters this kind of values
+		 * if stof fails to find any valid convertion, it throws an
+		 * invalid_argument exception*/
+		if (s.fail()) {
+			s.clear();
+			s >> tmp;
+			value = std::stof(tmp.c_str());
+		}
+
+		/* This check prevent encountering any zero values in distances matrices */
+		if (value != 0) valid = true;
+	}
+
+	s.ignore();
+	return valid ? value : NAN;
+}
+
+
 compressed_lower_distance_matrix read_point_cloud(std::istream& input_stream) {
 	std::vector<std::vector<value_t>> points;
 


### PR DESCRIPTION
Dear Ulrich,

Playing with `ripser` using datasets where data was pruned using in my case `collapser`, I encountered an unexpected behaviour when reading distance matrices where `inf` values are present in the input file. `std::istream` or `std::istringstream` returns 0 instead of `inf` if they encounter `INF, Inf, etc.` in an input file when you try to directly assign the stream into a `float` or `double` variable.

Why are `inf` values in this distances matrices ? Because, when pruning data from the original distances matrices, I replace a pruned data by `inf`.

In attachment you'll find a distance matrix not pruned `dense.txt`. Its pruned version `dense_pruned.txt` and the lower and upper part of the `dense_pruned.txt` to test the lower and upper reader. 

Command to test the different datasets:

```
./ripser --format distance --dim 2 dense.txt
./ripser --format distance --dim 2 dense_pruned.txt
./ripser --format lower --dim 2 lower_pruned.txt
./ripser --format upper --dim 2 upper_pruned.txt
```

The expected results is:

```
persistence intervals in dim 0:
 [0,0.8924)
 [0,0.9461)
 [0,0.9973)
 [0,1.0168)
 [0,1.0494)
 [0,1.0708)
 [0,1.0775)
 [0,1.0779)
 [0,1.1533)
 [0,1.2462)
 [0,1.2797)
 [0,1.2953)
 [0,1.3245)
 [0,1.3601)
 [0,1.3732)
 [0,1.3759)
 [0,1.3804)
 [0,1.3805)
 [0,1.3957)
 [0, )
persistence intervals in dim 1:
 [1.5254,1.5512)
 [1.5123,1.5498)
 [1.465,1.5809)
 [1.4599,1.4958)
 [1.4489,1.4493)
 [1.4368,1.5328)
 [1.4097,1.4682)
persistence intervals in dim 2:
 [1.6036,1.608)
```

Please, feel free to suggest any modifications or if you have any remarks.

Best,
Julián