### PR TITLE
Prevents simplex assembly in last dimension

### DIFF
--- a/ripser.cpp
+++ b/ripser.cpp
@@ -578,7 +578,8 @@ public:
 #endif
 				auto cofacet = cofacets.next();
 				if (get_diameter(cofacet) <= threshold) {
-					next_simplices.push_back({get_diameter(cofacet), get_index(cofacet)});
+					if (dim != dim_max)
+						next_simplices.push_back({get_diameter(cofacet), get_index(cofacet)});
 					if (!is_in_zero_apparent_pair(cofacet, dim) &&
 					    (pivot_column_index.find(get_entry(cofacet)) == pivot_column_index.end()))
 						columns_to_reduce.push_back({get_diameter(cofacet), get_index(cofacet)});


### PR DESCRIPTION
Hello,

Here is a one line fix that will drastically reduce memory consumption. During column assembly, simplices are aggregated and used as a base for columns in the next dimension. Aggregating these simplices is not necessary when assembling columns in last dimension.

The following results were obtained on my laptop (i7 8565U - up to 4.6GHz, 16 GB Ram) :

| Dataset                   | Peak consumption before (GB) | Peak consumption after (GB) |
| ------------------------- | ---------------------------- | --------------------------- |
| sphere192 - dim 2         | 0.119                        | 0.070                       |
| o3_1024 - dim 3 - t = 1.8 | 0.045                        | 0.014                       |
| o3_4096 - dim 3 - t = 1.4 | 1.166                        | 0.150                       |
| fractal - dim 2           | 0.539                        | 0.012                       |
| dragon - dim 1            | 0.099                        | 0.099                       |
| random16 - dim 7          | 0.206                        | 0.085                       |

Best,
Sydney