### PR TITLE
Add SPARSE to read_file

### DIFF
--- a/ripser.cpp
+++ b/ripser.cpp
@@ -1165,6 +1165,8 @@ compressed_lower_distance_matrix read_file(std::istream& input_stream, const fil
 		return read_point_cloud(input_stream);
 	case DIPHA:
 		return read_dipha(input_stream);
+	case SPARSE:
+		return read_sparse_distance_matrix(input_stream);
 	default:
 		return read_binary(input_stream);
 	}


### PR DESCRIPTION
Hello,
in order to add sparse support to ripser-live, it looks like we need this simple piece here? Then with the obvious 1-line additions to index.html and ripser-web.js it seems to work on a local installation.