### PR TITLE
Optionally use Boost's d_ary_heap instead of std::priority_queue

### DIFF
--- a/ripser.cpp
+++ b/ripser.cpp
@@ -728,6 +728,15 @@ public:
 #endif
 
 		compressed_sparse_matrix<diameter_entry_t> reduction_matrix;
+
+#ifdef USE_BOOST_HEAP
+		boost::heap::d_ary_heap<diameter_entry_t, boost::heap::arity<16>,
+		                    boost::heap::compare<greater_diameter_or_smaller_index_comp<diameter_entry_t>>>
+#else
+		std::priority_queue<diameter_entry_t, std::vector<diameter_entry_t>,
+		                    greater_diameter_or_smaller_index_comp<diameter_entry_t>>
+#endif
+		    working_reduction_column, working_coboundary;
 		
 #ifdef INDICATE_PROGRESS
 		std::chrono::steady_clock::time_point next = std::chrono::steady_clock::now() + time_step;
@@ -740,14 +749,7 @@ public:
 
 			reduction_matrix.append_column();
 
-#ifdef USE_BOOST_HEAP
-			boost::heap::d_ary_heap<diameter_entry_t, boost::heap::arity<16>,
-			                    boost::heap::compare<greater_diameter_or_smaller_index_comp<diameter_entry_t>>>
-#else
-			std::priority_queue<diameter_entry_t, std::vector<diameter_entry_t>,
-			                    greater_diameter_or_smaller_index_comp<diameter_entry_t>>
-#endif
-			    working_reduction_column, working_coboundary;
+			working_reduction_column.clear(); working_coboundary.clear();
 
 			diameter_entry_t e, pivot = init_coboundary_and_get_pivot(
 			                        column_to_reduce, working_coboundary, dim, pivot_column_index);

--- a/ripser.cpp
+++ b/ripser.cpp
@@ -54,6 +54,10 @@
 #include <sstream>
 #include <unordered_map>
 
+#ifdef USE_BOOST_HEAP
+#include <boost/heap/d_ary_heap.hpp>
+#endif
+
 #ifdef USE_ROBINHOOD_HASHMAP
 
 #include "robin-hood-hashing/src/include/robin_hood.h"
@@ -202,7 +206,7 @@ void set_coefficient(diameter_entry_t& p, const coefficient_t c) {
 }
 
 template <typename Entry> struct greater_diameter_or_smaller_index_comp {
-	bool operator()(const Entry& a, const Entry& b) {
+	bool operator()(const Entry& a, const Entry& b) const {
 		return greater_diameter_or_smaller_index(a, b);
 	}
 };
@@ -736,8 +740,13 @@ public:
 
 			reduction_matrix.append_column();
 
+#ifdef USE_BOOST_HEAP
+			boost::heap::d_ary_heap<diameter_entry_t, boost::heap::arity<16>,
+			                    boost::heap::compare<greater_diameter_or_smaller_index_comp<diameter_entry_t>>>
+#else
 			std::priority_queue<diameter_entry_t, std::vector<diameter_entry_t>,
 			                    greater_diameter_or_smaller_index_comp<diameter_entry_t>>
+#endif
 			    working_reduction_column, working_coboundary;
 
 			diameter_entry_t e, pivot = init_coboundary_and_get_pivot(


### PR DESCRIPTION
Hello,
I don't really expect this to get merged (although you are certainly welcome to). In another project (no persistence), I noticed that d-ary heaps can perform very well in practice, much better than theoretically interesting structures like Fibonacci, and I think it is useful to advertise this fact. I did not conduct an exhaustive search for the best arity. In my other project it was around 7 but performance did not vary much from 5 to 20.

While I was touching this, I couldn't resist recycling the priority queues, to save a bit in allocations.

For `ripser --format point-cloud examples/o3_1024.txt`, the running time is

| version | time (s) |
| --- | --- |
| master | 0.965 |
| without boost | 0.9 |
| with boost | 0.719 |